### PR TITLE
Update render.py to support Raspberry Pi and Linux 

### DIFF
--- a/coolledx/render.py
+++ b/coolledx/render.py
@@ -95,7 +95,7 @@ def render_text_to_image(
     del draw
 
     # crop the canvas
-    return img.crop((0, 0, x_offset, y_max+2))  #2 pixel vertical adjustment prevents bottom text cut off
+    return img.crop((0, 0, x_offset, y_max+1))  #pixel vertical adjustment prevents bottom text cut off
 
 
 

--- a/coolledx/render.py
+++ b/coolledx/render.py
@@ -282,13 +282,13 @@ def create_image_output(
 
     if text is not None:
         # length of string (pretty irrelevant because the image will be used anyway)
-        pixel_payload += len(text).to_bytes(1, byteorder="big")
+        pixel_payload += len(text).to_bytes(2, byteorder="big")  #changed to 2 to allow length>255
 
         # character string (pretty irrelevant because the image will be used anyway)
-        char_metadata = bytearray(80)
+        char_metadata = bytearray(79)          #changed from 80 to allow for 2-byte text message length
         for i, _ in enumerate(text):
-            if i < 80:
-                char_metadata[i] = 0x30
+            if i < 79:                         #changed from 80 to allow for 2-byte text message length
+                char_metadata[i] = 0x30        
         pixel_payload += char_metadata
 
     width, height = image.size

--- a/coolledx/render.py
+++ b/coolledx/render.py
@@ -69,10 +69,10 @@ def render_text_to_image(
                 parts.append((color, text))
 
     # create image canvas
-    img = Image.new(
-        "RGBA",
-        (2048, 64),
-        background_color if background_color != DEFAULT_BACKGROUND_COLOR else 0,
+    img=Image.new(
+      "RGBA",
+      (2048,16),
+      (ImageColor.getrgb(background_color)[0],ImageColor.getrgb(background_color)[1],ImageColor.getrgb(background_color)[2],255) 
     )
     draw = ImageDraw.Draw(img)
 
@@ -95,7 +95,8 @@ def render_text_to_image(
     del draw
 
     # crop the canvas
-    return img.crop((0, 0, x_offset, y_max))
+    return img.crop((0, 0, x_offset, y_max+2))  #2 pixel vertical adjustment prevents bottom text cut off
+
 
 
 def get_separate_pixel_bytefields(

--- a/coolledx/render.py
+++ b/coolledx/render.py
@@ -71,7 +71,7 @@ def render_text_to_image(
     # create image canvas
     img=Image.new(
       "RGBA",
-      (2048,16),
+      (2048,64),
       (ImageColor.getrgb(background_color)[0],ImageColor.getrgb(background_color)[1],ImageColor.getrgb(background_color)[2],255) 
     )
     draw = ImageDraw.Draw(img)

--- a/utils/mix.py
+++ b/utils/mix.py
@@ -25,6 +25,7 @@ cidx='rgbymcw'
 i=0
 cmd="\""
 text=sys.argv[1]
+oidx=len(sys.argv)
 
 if len(sys.argv)>2:
   j=True

--- a/utils/mix.py
+++ b/utils/mix.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python3
+
+import sys,os
+
+if len(sys.argv)<2:
+  print("-------------------------------------------------------------------------------")
+  print("Usage: " + sys.argv[0] + " \"Text Message\" <rgbymcwk (optional color mix)> <optional args>")
+  print("-------------------------------------------------------------------------------")
+  sys.exit()
+
+colors={
+"r":"<#FF0000>",
+"g":"<#00FF00>",
+"b":"<#0000FF>", 
+"y":"<#FFFF00>", 
+"m":"<#FF00FF>", 
+"c":"<#00FFFF>",
+"w":"<#FFFFFF>",
+"k":"<#000000>"
+}
+cidx='rgbymcw'
+i=0
+cmd="\""
+text=sys.argv[1]
+
+if len(sys.argv)>2:
+  j=True
+  oidx=2
+  for l in sys.argv[2]: 
+    if 'rgbymcwk'.find(l)<0:
+      j=False
+      break;
+  if j:
+    cidx=sys.argv[2]
+    oidx=3
+
+for letter in text:
+  if letter == ' ':
+    cmd+=letter
+  else:
+    cmd+=colors[cidx[i]]+letter
+    i+=1
+    if i>len(cidx)-1:
+      i=0
+
+cmd+="\""
+otherargs = ""
+print(sys.argv)
+for a in range (oidx,len(sys.argv)):
+  otherargs += " " + sys.argv[a]
+cmd = "./tweak_sign.py -t " + cmd + otherargs
+print(cmd)
+os.system(cmd)

--- a/utils/mix.py
+++ b/utils/mix.py
@@ -1,5 +1,8 @@
 #!/usr/bin/python3
 
+#creates a colorful text message
+#color mix can be specified using rgbymcwk as 2nd argument
+
 import sys,os
 
 if len(sys.argv)<2:

--- a/utils/mix.py
+++ b/utils/mix.py
@@ -45,7 +45,7 @@ for letter in text:
 
 cmd+="\""
 otherargs = ""
-print(sys.argv)
+#print(sys.argv)
 for a in range (oidx,len(sys.argv)):
   otherargs += " " + sys.argv[a]
 cmd = "./tweak_sign.py -t " + cmd + otherargs


### PR DESCRIPTION
Updated for Raspberry Pi Zero Bullseye and Linux Mint 20.3 (not tested on Windows)

This img call fails to display readable text when run from Raspberry Pi or Linux:
<pre>
img = Image.new("RGBA",
(2048, 64),
background_color if background_color != DEFAULT_BACKGROUND_COLOR else 0,
)
</pre>
Note:
To use 'arial' as default font (__init__.py), install mscorefonts ttf fonts
<pre>
sudo apt install ttf-mscorefonts-installer  
</pre>
or specify a font already on your system in /usr/share/fonts/truetype/                     

Command tested successfully on Raspberry Pi (Bullseye) and Linux Mint 20.3:
<pre>
 ./tweak_sign.py -t "<#ff0000>S<#00ff00>o<#0000ff>m<#ffff00>e <#00ffff>t<#ff00ff>e<#ff0000>x<#00ff00>t" -C "#000000" -s 200 -f DejaVuSans.ttf
</pre>